### PR TITLE
fix(ci): separate API release from main pipeline

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -1,0 +1,18 @@
+name: api-release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+
+permissions:
+  contents: write
+
+jobs:
+  create-api-version:
+    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
+    secrets: inherit
+    with:
+      apiPackagePath: api

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,22 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-api-changes:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    outputs:
-      api_changed: ${{ steps.filter.outputs.api }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            api:
-              - 'api/**'
-
   # ──────────────────────────────────────────────
   # Always-run jobs (PR + main)
   # ──────────────────────────────────────────────
@@ -88,34 +72,10 @@ jobs:
   # ──────────────────────────────────────────────
   # Release jobs (main branch only)
   # ──────────────────────────────────────────────
-  create-version-with-api:
-    if: github.ref == 'refs/heads/main' && needs.detect-api-changes.outputs.api_changed == 'true'
-    needs: [detect-api-changes]
-    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
-    secrets: inherit
-    with:
-      apiPackagePath: api
-
-  create-version-without-api:
-    if: github.ref == 'refs/heads/main' && needs.detect-api-changes.outputs.api_changed != 'true'
-    needs: [detect-api-changes]
-    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
-    secrets: inherit
-
   create-version:
     if: github.ref == 'refs/heads/main'
-    needs: [create-version-with-api, create-version-without-api]
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.resolve.outputs.version }}
-    steps:
-      - id: resolve
-        run: |
-          if [[ -n "${{ needs.create-version-with-api.outputs.version }}" ]]; then
-            echo "version=${{ needs.create-version-with-api.outputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${{ needs.create-version-without-api.outputs.version }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
+    secrets: inherit
 
   docker-build-push:
     if: github.ref == 'refs/heads/main'

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kcp-dev/multicluster-provider v0.5.1
 	github.com/kcp-dev/sdk v0.30.1
 	github.com/pkg/errors v0.9.1
-	github.com/platform-mesh/extension-manager-operator/api v0.7.58
+	github.com/platform-mesh/extension-manager-operator/api v0.0.0-local
 	github.com/platform-mesh/golang-commons v0.14.0
 	github.com/platform-mesh/subroutines v0.2.6
 	github.com/prometheus/client_golang v1.23.2

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>platform-mesh/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore self-referencing API module — operator uses replace directive to ./api",
+      "matchPackageNames": ["github.com/platform-mesh/extension-manager-operator/api"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- The `create-version` job depended on two mutually exclusive jobs (`create-version-with-api` / `create-version-without-api`). GitHub Actions skips any job whose `needs` list includes a skipped job, so the entire release chain (`docker-build-push` → `update-version` → `sbom` → `image-ocm`) was skipped on every push to `main` since PR #784.
- Instead of working around the skipped-dependency behavior, separates the concerns into two independent workflows:
  - **`pipeline.yml`** — main CI/CD without API detection logic — always runs `create-version` (without `apiPackagePath`), docker build, OCM, and chart update
  - **`api-release.yml`** — triggered only when `api/**` changes on `main`, tags the API module via `job-create-version` with `apiPackagePath: api`
- Disables Renovate self-updates for `github.com/platform-mesh/extension-manager-operator/api` since the operator uses a `replace` directive to `./api`
- Uses `v0.0.0-local` placeholder for the self-referencing API module in `go.mod` to make it explicit the version is never resolved