### PR TITLE
Add SBOM scanning with Trivy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,13 @@ jobs:
       appVersion: ${{ needs.create-version.outputs.version }}
       repoName: extension-manager-operator
       commit: ${{ github.sha }}
+
+  scan-sbom:
+    needs: [create-version, docker-build-push, sbom, image-ocm]
+    uses: platform-mesh/.github/.github/workflows/job-trivy-sbom.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    with:
+      componentVersion: ${{ needs.create-version.outputs.version }}


### PR DESCRIPTION
This PR adds SBOM scanning with Trivy to the release workflow. This job will take the latest SBOM, scan it for vulnerabilities in the code and the image, and upload all findings to the Security tab. From there, the `platform-mesh/security` team will be coordinating fixing issues that are found.

More information can be found in https://github.com/platform-mesh/backlog/issues/226
